### PR TITLE
Bug fixes / Enhancements

### DIFF
--- a/discover.py
+++ b/discover.py
@@ -26,17 +26,27 @@ def main():
 
 def check_200(url):
     tries = 0
-    while tries <= 5:
-        response = requests.get(url)
+    status_code = 0
+    MAX_TRIES = 10
+    while tries <= MAX_TRIES:
+        try:
+            response = requests.get(url, timeout=10)
+        except requests.exceptions.RequestException:
+            print('Connection error. Sleeping for 10 seconds...')
+            tries += 1
+            time.sleep(10)
+            continue
         status_code = response.status_code
-        time.sleep(0.5)
         if response.status_code == 403 and not '<title>Suspended Journal</title>' in response.text:
             raise Exception('You\'re banned from LiveJournal. ABORTING.')
         elif response.status_code not in (200, 404, 410, 403):
             tries += 1
         else:
             return status_code
-    return status_code
+    if tries <= MAX_TRIES:
+        return status_code
+    else:
+        raise Exception('Subsequent failed attempts. ABORTING.')
 
 if __name__ == '__main__':
     main()

--- a/discover.py
+++ b/discover.py
@@ -16,6 +16,7 @@ def main():
     if item_type == "profiles":
         profiles = []
         for profileid in range(int(start_num), int(end_num) + 1):
+            time.sleep(0.5)
             status_code = str(check_200('http://www.livejournal.com/profile?userid='+str(profileid)))
             print('Received status code ' + status_code + ' for profile ' + str(profileid) + '.')
             sys.stdout.flush()


### PR DESCRIPTION
In check_200:
– Check in the end if we reached the max number of tries, then raise exception instead of returning status code
– Added timeout to requests.get call – preventing indefinite hangs
– Handling connection errors by catching appropriate exceptions and retrying – otherwise item would just fail
– Moved 0.5 seconds sleep to caller function (in fact first I forgot to put it back, then found it more logical to put into main()).
