### PR TITLE
Added handling of HTTP response 500

### DIFF
--- a/discover.py
+++ b/discover.py
@@ -42,7 +42,7 @@ def check_200(url):
             print('You\'re banned from LiveJournal. Sleeping for 1 hour, then ABORTING.')
             time.sleep(3600)
             raise Exception('Banned from LiveJournal. ABORTING.')
-        elif response.status_code not in (200, 404, 410, 403):
+        elif response.status_code not in (200, 404, 410, 403, 500):
             tries += 1
         else:
             return status_code

--- a/pipeline.py
+++ b/pipeline.py
@@ -33,7 +33,7 @@ if StrictVersion(seesaw.__version__) < StrictVersion("0.1.5"):
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
 
-VERSION = "20160421.01"
+VERSION = "20161215.01"
 USER_AGENT = 'ArchiveTeam'
 TRACKER_ID = 'livejournaldisco'
 TRACKER_HOST = 'tracker.archiveteam.org'


### PR DESCRIPTION
Seems there are a few journals, that always return a 500-error. Script should now not stop on this.

Ex: http://www.livejournal.com/profile?userid=2374032